### PR TITLE
Add support for logging drivers

### DIFF
--- a/dockerflags.go
+++ b/dockerflags.go
@@ -70,6 +70,8 @@ func init() {
 	DockerFlags["run"].String([]string{"-ipc"}, "", "Default is to create a private IPC namespace (POSIX SysV IPC) for the container\n'container:<name|id>': reuses another container shared memory, semaphores and message queues\n'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.")
 	DockerFlags["run"].String([]string{"-restart"}, "", "Restart policy to apply when a container exits (no, on-failure[:max-retry], always)")
 	DockerFlags["run"].Bool([]string{"-read-only"}, false, "Mount the container's root filesystem as read only")
+	DockerFlags["run"].String([]string{"#log-driver", "-log-driver"}, "json-file", "Logging driver for container")
+	DockerFlags["run"].Var([]string{"-log-opt"}, "Log driver options")
 
 	// Define DockerFlags["exec"]
 	DockerFlags["exec"] = flags.New("docker")

--- a/examples/fugu.log-driver.yml
+++ b/examples/fugu.log-driver.yml
@@ -1,0 +1,5 @@
+image: ubuntu
+name: my-ubuntu
+log-driver: syslog
+log-opt:
+  - syslog-address=tcp://192.168.0.42:123

--- a/fugu/usage.txt
+++ b/fugu/usage.txt
@@ -82,6 +82,8 @@ Docker options:
                                'container:<name|id>': reuses another container shared memory, semaphores and message queues
                                'host': use the host shared memory,semaphores and message queues inside the container.  Note: the host mode gives the container full access to local shared memory and is therefore considered insecure.
   --link=[]                  Add link to another container in the form of <name|id>:alias
+  --log-driver="json-file"   Logging driver for container
+  --log-opt=[]               Log driver options
   --lxc-conf=[]              (lxc exec-driver only) Add custom lxc options --lxc-conf="lxc.cgroup.cpuset.cpus = 0,1"
   -m, --memory=""            Memory limit (format: <number><optional unit>, where unit = b, k, m or g)
   --mac-address=""           Container MAC address (e.g. 92:d0:c6:0a:29:33)

--- a/fugu_test.go
+++ b/fugu_test.go
@@ -360,6 +360,14 @@ func TestCommandRun(t *testing.T) {
 		strOut:   "docker run --name=my-ubuntu --volume=" + usr.HomeDir + "/Go:/root/Go --volume=/tmp foo",
 		errOut:   nil,
 	}).Test(t)
+
+	(&DockerCommandTest{
+		testDesc: "command with log-driver and log-opt flag",
+		command:  "run",
+		argsIn:   []string{"--image=foo", "--source=file://examples/fugu.log-driver.yml"},
+		strOut:   "docker run --log-driver=syslog --log-opt=syslog-address=tcp://192.168.0.42:123 --name=my-ubuntu foo",
+		errOut:   nil,
+	}).Test(t)
 }
 
 func TestCommandExec(t *testing.T) {


### PR DESCRIPTION
This pull request adds support for logging drivers of docker.

Use `--log-driver` to select the logging behavior when running containers.
Use `--log-opt` to specify additional logging drivers options.

[Docker Docs / Logging drivers](https://docs.docker.com/docker/reference/run/#logging-drivers-log-driver) for details.

Fugu is very nice application.
I use fugu almost every day.

Thanks.
